### PR TITLE
Issues with NonGeneric.Emit.Call 

### DIFF
--- a/Sigil/Emit.cs
+++ b/Sigil/Emit.cs
@@ -299,12 +299,12 @@ namespace Sigil
             return ret;
         }
 
-        internal Delegate InnerCreateDelegate(Type delegateType, out string instructions, OptimizationOptions optimizationOptions)
+        internal Delegate InnerCreateDelegate(Type delegateType, out string instructions, OptimizationOptions optimizationOptions, bool logInstructions = true)
         {
             Seal(optimizationOptions);
 
             var il = DynMethod.GetILGenerator();
-            instructions = IL.UnBuffer(il);
+            instructions = IL.UnBuffer(il, logInstructions);
 
             AutoNamer.Release(this);
 
@@ -373,7 +373,7 @@ namespace Sigil
         /// the returned method fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public MethodBuilder CreateMethod(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public MethodBuilder CreateMethod(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true)
         {
             if (MtdBuilder == null)
             {
@@ -391,7 +391,7 @@ namespace Sigil
             MethodBuilt = true;
 
             var il = MtdBuilder.GetILGenerator();
-            instructions = IL.UnBuffer(il);
+            instructions = IL.UnBuffer(il, logInstructions);
 
             AutoNamer.Release(this);
 
@@ -430,7 +430,7 @@ namespace Sigil
         /// the returned constructor fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public ConstructorBuilder CreateConstructor(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public ConstructorBuilder CreateConstructor(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true)
         {
             if (ConstrBuilder == null || !IsBuildingConstructor)
             {
@@ -448,7 +448,7 @@ namespace Sigil
             Seal(optimizationOptions);
 
             var il = ConstrBuilder.GetILGenerator();
-            instructions = IL.UnBuffer(il);
+            instructions = IL.UnBuffer(il, logInstructions);
 
             AutoNamer.Release(this);
 
@@ -487,7 +487,7 @@ namespace Sigil
         /// the returned constructor fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public ConstructorBuilder CreateTypeInitializer(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All) 
+        public ConstructorBuilder CreateTypeInitializer(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true) 
         {
             if (ConstrBuilder == null || IsBuildingConstructor) 
             {
@@ -505,7 +505,7 @@ namespace Sigil
             Seal(optimizationOptions);
 
             var il = ConstrBuilder.GetILGenerator();
-            instructions = IL.UnBuffer(il);
+            instructions = IL.UnBuffer(il, logInstructions);
 
             AutoNamer.Release(this);
 

--- a/Sigil/Impl/BufferedILGenerator.cs
+++ b/Sigil/Impl/BufferedILGenerator.cs
@@ -998,6 +998,9 @@ namespace Sigil.Impl
                         ret(il);
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--BeginExceptionBlock--");
                 }
             );

--- a/Sigil/Impl/BufferedILGenerator.cs
+++ b/Sigil/Impl/BufferedILGenerator.cs
@@ -76,9 +76,11 @@ namespace Sigil.Impl
         {
         }
 
-        public string UnBuffer(ILGenerator il)
+        public string UnBuffer(ILGenerator il, bool logInstructions = true)
         {
-            var log = new StringBuilder();
+            StringBuilder log = null;
+            if (logInstructions)
+                log = new StringBuilder();
 
             // First thing will always be a Mark for tracing purposes; no reason to actually do it
             for(var i = 2; i < Buffer.Count; i++)
@@ -88,7 +90,9 @@ namespace Sigil.Impl
                 x(il, false, log);
             }
 
-            return log.ToString();
+            if (log != null)
+                return log.ToString();
+            return null;
         }
 
         private Dictionary<int, int> LengthCache = new Dictionary<int, int>();
@@ -253,6 +257,9 @@ namespace Sigil.Impl
                         il.Emit(op);
                     }
 
+                    if (log == null)
+                        return;
+
                     if (ExtensionMethods.IsPrefix(op))
                     {
                         log.Append(op.ToString());
@@ -289,6 +296,9 @@ namespace Sigil.Impl
                         il.Emit(op);
                     }
 
+                    if (log == null)
+                        return;
+
                     if (ExtensionMethods.IsPrefix(op))
                     {
                         log.Append(op.ToString());
@@ -318,6 +328,9 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, b);
                     }
+
+                    if (log == null)
+                        return;
 
                     if (ExtensionMethods.IsPrefix(op))
                     {
@@ -349,6 +362,9 @@ namespace Sigil.Impl
                         il.Emit(op, s);
                     }
 
+                    if (log == null)
+                        return;
+
                     if (ExtensionMethods.IsPrefix(op))
                     {
                         log.Append(op + "" + s + ".");
@@ -378,6 +394,9 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, i);
                     }
+
+                    if (log == null)
+                        return;
 
                     if (ExtensionMethods.IsPrefix(op))
                     {
@@ -414,7 +433,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, asInt);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + ui);
                 }
             );
@@ -437,7 +459,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, l);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + l); 
                 }
             );
@@ -466,7 +491,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, asLong);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + ul); 
                 }
             );
@@ -489,7 +517,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, f);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + f); 
                 }
             );
@@ -512,7 +543,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, d);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + d);
                 });
 
@@ -534,6 +568,9 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, method);
                     }
+
+                    if (log == null)
+                        return;
 
                     var mtdString = method is MethodBuilder ? method.Name : method.ToString();
 
@@ -573,6 +610,9 @@ namespace Sigil.Impl
                         il.Emit(op, cons);
                     }
 
+                    if (log == null)
+                        return;
+
                     var mtdString = cons is ConstructorBuilder ? cons.Name : cons.ToString();
 
                     log.AppendLine(op + " " + mtdString);
@@ -608,7 +648,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, cons);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + cons); 
                 }
             );
@@ -631,6 +674,9 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, type);
                     }
+
+                    if (log == null)
+                        return;
 
                     log.AppendLine(op + " " + type); 
                 }
@@ -655,6 +701,9 @@ namespace Sigil.Impl
                         il.Emit(op, field);
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " " + field); 
                 }
             );
@@ -677,7 +726,10 @@ namespace Sigil.Impl
                     {
                         il.Emit(op, str);
                     }
-                    
+
+                    if (log == null)
+                        return;
+
                     log.AppendLine(op + " '" + str.Replace("'", @"\'") + "'");
                 }
             );
@@ -712,6 +764,9 @@ namespace Sigil.Impl
                         il.Emit(localOp, l);
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine(localOp + " " + label);
                 }
             );
@@ -745,6 +800,9 @@ namespace Sigil.Impl
                         var ls = LinqAlternative.Select(labels, l => l.LabelDel(il)).ToArray();
                         il.Emit(localOp, ls);
                     }
+
+                    if (log == null)
+                        return;
 
                     log.AppendLine(localOp + " " + Join(", ", ((LinqArray<Label>)labels).AsEnumerable()));
                 }
@@ -787,6 +845,9 @@ namespace Sigil.Impl
                             il.Emit(op, l);
                         }
 
+                        if (log == null)
+                            return;
+
                         log.AppendLine(op + " " + local);
                     }
             );
@@ -809,6 +870,9 @@ namespace Sigil.Impl
                     {
                         il.EmitCalli(op, callConventions, returnType, parameterTypes, null);
                     }
+
+                    if (log == null)
+                        return;
 
                     log.AppendLine(op + " " + callConventions + " " + returnType + " " + Join(" ", ((LinqArray<Type>)parameterTypes).AsEnumerable()));
                 }
@@ -835,6 +899,9 @@ namespace Sigil.Impl
                     {
                         il.EmitCall(op, method, arglist);
                     }
+
+                    if (log == null)
+                        return;
 
                     var mtdString = method is MethodBuilder ? method.Name : method.ToString();
 
@@ -878,6 +945,9 @@ namespace Sigil.Impl
                     {
                         il.EmitCalli(OpCodes.Calli, callingConvention, returnType, parameterTypes, arglist);
                     }
+
+                    if (log == null)
+                        return;
 
                     log.AppendLine(OpCodes.Calli + " " + callingConvention + " " + returnType + " " + Join(" ", (IEnumerable<Type>)parameterTypes) + " __arglist(" + Join(", ", arglist) + ")");
                 }
@@ -953,6 +1023,9 @@ namespace Sigil.Impl
                         il.BeginCatchBlock(exception);
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--BeginCatchBlock(" + exception + ")--");
                 }
             );
@@ -976,6 +1049,9 @@ namespace Sigil.Impl
                         il.EndExceptionBlock();
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--EndExceptionBlock--");
                 }
             );
@@ -994,6 +1070,9 @@ namespace Sigil.Impl
             Buffer.Add(
                 (il, logOnly, log) =>
                 {
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--EndCatchBlock--");
                 }
             );
@@ -1017,6 +1096,9 @@ namespace Sigil.Impl
                         il.BeginFinallyBlock();
                     }
 
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--BeginFinallyBlock--");
                 }
             );
@@ -1035,6 +1117,9 @@ namespace Sigil.Impl
             Buffer.Add(
                 (il, logOnly, log) =>
                 {
+                    if (log == null)
+                        return;
+
                     log.AppendLine("--EndFinallyBlock--");
                 }
             );
@@ -1100,6 +1185,9 @@ namespace Sigil.Impl
                         var l = label.LabelDel(il);
                         il.MarkLabel(l);
                     }
+
+                    if (log == null)
+                        return;
 
                     log.AppendLine();
                     log.AppendLine(label + ":");

--- a/Sigil/NonGeneric/Emit.Call.cs
+++ b/Sigil/NonGeneric/Emit.Call.cs
@@ -63,7 +63,8 @@ namespace Sigil.NonGeneric
                 methodInfo = dynMethod;
             }
 
-            return Call(methodInfo, arglist);
+            InnerEmit.Call(emit.InnerEmit, arglist);
+            return this;
         }
     }
 }

--- a/Sigil/NonGeneric/Emit.cs
+++ b/Sigil/NonGeneric/Emit.cs
@@ -177,7 +177,7 @@ namespace Sigil.NonGeneric
         /// the returned delegate fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public Delegate CreateDelegate(Type delegateType, out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public Delegate CreateDelegate(Type delegateType, out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true)
         {
             if (EmitType != NonGenericEmitType.DynamicMethod)
             {
@@ -199,7 +199,7 @@ namespace Sigil.NonGeneric
                 return CreatedDelegate;
             }
 
-            CreatedDelegate = InnerEmit.InnerCreateDelegate(delegateType, out instructions, optimizationOptions);
+            CreatedDelegate = InnerEmit.InnerCreateDelegate(delegateType, out instructions, optimizationOptions, logInstructions);
 
             return CreatedDelegate;
         }
@@ -215,7 +215,7 @@ namespace Sigil.NonGeneric
         public Delegate CreateDelegate(Type delegateType, OptimizationOptions optimizationOptions = OptimizationOptions.All)
         {
             string ignored;
-            return CreateDelegate(delegateType, out ignored, optimizationOptions);
+            return CreateDelegate(delegateType, out ignored, optimizationOptions, false);
         }
 
         /// <summary>
@@ -232,9 +232,9 @@ namespace Sigil.NonGeneric
         /// the returned delegate fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public DelegateType CreateDelegate<DelegateType>(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public DelegateType CreateDelegate<DelegateType>(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true)
         {
-            return (DelegateType)(object)CreateDelegate(typeof(DelegateType), out instructions, optimizationOptions);
+            return (DelegateType)(object)CreateDelegate(typeof(DelegateType), out instructions, optimizationOptions, logInstructions);
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Sigil.NonGeneric
         public DelegateType CreateDelegate<DelegateType>(OptimizationOptions optimizationOptions = OptimizationOptions.All)
         {
             string ignored;
-            return CreateDelegate<DelegateType>(out ignored, optimizationOptions);
+            return CreateDelegate<DelegateType>(out ignored, optimizationOptions, false);
         }
 
         private static bool HasFlag(CallingConventions value, CallingConventions flag)
@@ -345,7 +345,7 @@ namespace Sigil.NonGeneric
         /// the returned method fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public MethodBuilder CreateMethod(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public MethodBuilder CreateMethod(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = false)
         {
             if (EmitType != NonGenericEmitType.Method)
             {
@@ -362,7 +362,7 @@ namespace Sigil.NonGeneric
 
             InnerEmit.MtdBuilder = methodBuilder;
 
-            CreatedMethod = InnerEmit.CreateMethod(out instructions, optimizationOptions);
+            CreatedMethod = InnerEmit.CreateMethod(out instructions, optimizationOptions, logInstructions);
 
             return CreatedMethod;
         }
@@ -380,7 +380,7 @@ namespace Sigil.NonGeneric
         public MethodBuilder CreateMethod(OptimizationOptions optimizationOptions = OptimizationOptions.All)
         {
             string ignored;
-            return CreateMethod(out ignored, optimizationOptions);
+            return CreateMethod(out ignored, optimizationOptions, false);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace Sigil.NonGeneric
         /// the returned constructor fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public ConstructorBuilder CreateConstructor(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All)
+        public ConstructorBuilder CreateConstructor(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true)
         {
             if (EmitType != NonGenericEmitType.Constructor)
             {
@@ -501,7 +501,7 @@ namespace Sigil.NonGeneric
 
             InnerEmit.ConstrBuilder = constructorBuilder;
 
-            CreatedConstructor = InnerEmit.CreateConstructor(out instructions, optimizationOptions);
+            CreatedConstructor = InnerEmit.CreateConstructor(out instructions, optimizationOptions, logInstructions);
 
             return CreatedConstructor;
         }
@@ -519,7 +519,7 @@ namespace Sigil.NonGeneric
         public ConstructorBuilder CreateConstructor(OptimizationOptions optimizationOptions = OptimizationOptions.All)
         {
             string ignored;
-            return CreateConstructor(out ignored, optimizationOptions);
+            return CreateConstructor(out ignored, optimizationOptions, false);
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace Sigil.NonGeneric
         /// the returned constructor fails validation (indicative of a bug in Sigil) or
         /// behaves unexpectedly (indicative of a logic bug in the consumer code).
         /// </summary>
-        public ConstructorBuilder CreateTypeInitializer(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All) 
+        public ConstructorBuilder CreateTypeInitializer(out string instructions, OptimizationOptions optimizationOptions = OptimizationOptions.All, bool logInstructions = true) 
         {
             if (EmitType != NonGenericEmitType.TypeInitializer) {
                 throw new InvalidOperationException("Emit was not created to build a type initializer, thus CreateTypeInitializer cannot be called");
@@ -553,7 +553,7 @@ namespace Sigil.NonGeneric
 
             InnerEmit.ConstrBuilder = constructorBuilder;
 
-            CreatedConstructor = InnerEmit.CreateTypeInitializer(out instructions, optimizationOptions);
+            CreatedConstructor = InnerEmit.CreateTypeInitializer(out instructions, optimizationOptions, logInstructions);
 
             return CreatedConstructor;
         }
@@ -571,7 +571,7 @@ namespace Sigil.NonGeneric
         public ConstructorBuilder CreateTypeInitializer(OptimizationOptions optimizationOptions = OptimizationOptions.All) 
         {
             string ignored;
-            return CreateTypeInitializer(out ignored, optimizationOptions);
+            return CreateTypeInitializer(out ignored, optimizationOptions, false);
         }
 
         /// <summary>

--- a/Sigil/project.json
+++ b/Sigil/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "packOptions": {
     "summary": "A fail-fast validation helper for .NET CIL generation.",
     "tags": [ "cil msil il bytecode" ],

--- a/SigilTests.DNX/project.json
+++ b/SigilTests.DNX/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "description": "SigilTests Console Application",
   "authors": [ "Kevin Montrose" ],

--- a/SigilTests/Multiply.cs
+++ b/SigilTests/Multiply.cs
@@ -47,10 +47,10 @@ namespace SigilTests
             e1.LoadArgument(1);
             e1.UnsignedMultiplyOverflow();
             e1.Return();
-
-            var d1 = e1.CreateDelegate();
-
-            Assert.AreEqual(3.14 * 1.59, d1(3.14, 1.59));
+            string i;
+            var d1 = e1.CreateDelegate(out i);
+            double d2 = 3.14 * 1.59;
+                Assert.AreEqual(d2, d1(3.14, 1.59));
         }
     }
 }


### PR DESCRIPTION
Hi,

The function Sigil.NonGeneric.Emit.Call ends up calling this overload of Emit.Call:
public Emit<DelegateType> Call(MethodInfo method, Type[] arglist = null)

That overload is for already builded types and, in fact, the inner MethodBuilder object does not seems to like the call to GetParameters() (NotSupportedException -> Type has not beed created).

Is it possible to fix this calling the other overload of Emit.Call?

Thanks!