### PR TITLE
Feature/boxed type assignability

### DIFF
--- a/Sigil/Impl/ExtensionMethods.cs
+++ b/Sigil/Impl/ExtensionMethods.cs
@@ -119,8 +119,12 @@ namespace Sigil.Impl
             if (type1.IsPointer && type2 == TypeOnStack.Get<NativeIntType>()) return true;
             if (type2.IsPointer && type1 == TypeOnStack.Get<NativeIntType>()) return true;
 
-            if ((type1.IsPointer || type1.IsReference) && !(type2.IsPointer || type2.IsReference)) return false;
-            if ((type2.IsPointer || type2.IsReference) && !(type1.IsPointer || type1.IsReference)) return false;
+            // it's possible to assign a struct* to an interface or object
+            if(!(type2.IsPointerToValueType && (type1.IsInterface || type1.Type.Equals(typeof(object)))))
+            {
+                if((type1.IsPointer || type1.IsReference) && !(type2.IsPointer || type2.IsReference)) return false;
+                if((type2.IsPointer || type2.IsReference) && !(type1.IsPointer || type1.IsReference)) return false;
+            }
 
             if (type1.IsPointer || type1.IsReference)
             {
@@ -172,7 +176,7 @@ namespace Sigil.Impl
             if (t1 == typeof(object) && !TypeHelpers.IsValueType(t2)) return true;
 
             // you have to box in this case
-            if (t1 == typeof(object) && TypeHelpers.IsValueType(t2)) return false;
+            if((t1 == typeof(object) || TypeHelpers.IsInterface(t1)) && TypeHelpers.IsValueType(t2)) return false;
 
             var t1Bases = GetBases(t1);
             var t2Bases = GetBases(t2);
@@ -181,7 +185,7 @@ namespace Sigil.Impl
 
             if (TypeHelpers.IsInterface(t1))
             {
-                var t2Interfaces = (LinqArray<Type>)t2.GetInterfaces();
+                var t2Interfaces = t2.IsPointer ? (LinqArray<Type>)t2.GetElementType().GetInterfaces() : (LinqArray<Type>)t2.GetInterfaces();
 
                 return t2Interfaces.Any(t2i => TypeOnStack.Get(t1).IsAssignableFrom(TypeOnStack.Get(t2i)));
             }

--- a/Sigil/Impl/TypeOnStack.cs
+++ b/Sigil/Impl/TypeOnStack.cs
@@ -60,13 +60,27 @@ namespace Sigil.Impl
         public Type Type { get; private set; }
 
         public bool IsReference { get { return Type.IsByRef; } }
+
         public bool IsPointer { get { return Type.IsPointer; } }
+
         public bool IsArray { get { return Type.IsArray; } }
 
+#if NETSTANDARD1_5
+        public bool IsPointerToValueType { get { return Type.IsPointer && Type.GetElementType().GetTypeInfo().IsValueType; } }
+#else
+        public bool IsPointerToValueType { get { return Type.IsPointer && Type.GetElementType().IsValueType; } }
+#endif
+
+        public bool IsInterface { get { return TypeHelpers.IsInterface(Type); } }
+
         public bool HasAttachedMethodInfo { get; private set; }
+
         public CallingConventions CallingConvention { get; private set; }
+
         public Type InstanceType { get; private set; }
+
         public Type ReturnType { get; private set; }
+
         public Type[] ParameterTypes { get; private set; }
 
         public bool IsMarkable { get { return UsedBy != null; } }

--- a/Sigil/NonGeneric/Emit.Call.cs
+++ b/Sigil/NonGeneric/Emit.Call.cs
@@ -63,7 +63,8 @@ namespace Sigil.NonGeneric
                 methodInfo = dynMethod;
             }
 
-            return Call(methodInfo, arglist);
+            InnerEmit.Call(emit.InnerEmit, arglist);
+            return this;
         }
     }
 }

--- a/SigilTests/Calls.cs
+++ b/SigilTests/Calls.cs
@@ -128,6 +128,44 @@ namespace SigilTests
         }
 
         [Test]
+        public void CallInterfaceMethodOnValueTypeAddress()
+        {
+            // Issue #53. dispatch interface method to address of value type using constrained callvirt
+
+            var equals = typeof(IEquatable<int>).GetMethod("Equals");
+            var e1 = Emit<Func<int, bool>>.NewDynamicMethod();
+            e1.LoadArgumentAddress(0);
+            e1.LoadConstant(1);
+            e1.CallVirtual(equals, typeof(int));
+            e1.Return();
+
+            var d1 = e1.CreateDelegate();
+
+            Assert.IsTrue(d1(1));
+            Assert.IsFalse(d1(2));
+        }
+
+        [Test]
+        public void CallObjectMethodOnValueTypeAddress()
+        {
+            // Issue #53. dispatch object method to address of value type using constrained callvirt
+
+            var equals = typeof(object).GetMethod("Equals", new[] { typeof(object) });
+            var e1 = Emit<Func<int, bool>>.NewDynamicMethod();
+            e1.LoadArgumentAddress(0);
+            e1.LoadConstant(1);
+            e1.Box<int>();
+            e1.CallVirtual(equals, typeof(int));
+            e1.Return();
+
+            var d1 = e1.CreateDelegate();
+
+            Assert.IsTrue(d1(1));
+            Assert.IsFalse(d1(2));
+        }
+
+
+        [Test]
         public void MultipleTailcalls()
         {
             var toString = typeof(object).GetMethod("ToString");


### PR DESCRIPTION
This fixes kevin-montrose#53. The IsAssignableFrom method wasn't accounting for the fact that you can assign a (boxed) struct to an interface.

I'm not very familiar with the codebase, so I don't know if this is the most effective way of fixing the bug, although the tests do all pass. Have a look at my code, feedback very welcome 😉

Closes PR #2