### PR TITLE
Exposed Stack and IsReachable properties on emitter.

### DIFF
--- a/Sigil/Emit.cs
+++ b/Sigil/Emit.cs
@@ -122,6 +122,29 @@ namespace Sigil
 
 		private readonly RollingVerifier CurrentVerifiers;
 
+        /// <summary>
+		/// The list of potential types on the current stack.
+		/// </summary>
+		public Type[][] Stack
+        {
+            get
+            {
+                return CurrentVerifiers.GetCurrentStack().Item2.Select(sl => sl.Select(si => si.Type).ToArray()).ToArray();
+            }
+        }
+
+        /// <summary> 
+        /// If false, the current location is not reachable.  This is useful information, for instance, when 
+        /// emitting an expression statement where the result is to be discarded, but the emitted node is a throw.
+        /// </summary>
+        public bool IsReachable
+        {
+            get
+            {
+                return !MustMark;
+            }
+        }
+
         private bool MustMark;
 
         private readonly LinqList<int> ElidableCasts;

--- a/Sigil/Impl/RollingVerifier.cs
+++ b/Sigil/Impl/RollingVerifier.cs
@@ -322,7 +322,7 @@ namespace Sigil.Impl
             return VerificationResult.Successful();
         }
 
-        private SigilTuple<bool, LinqStack<LinqList<TypeOnStack>>> GetCurrentStack()
+        internal SigilTuple<bool, LinqStack<LinqList<TypeOnStack>>> GetCurrentStack()
         {
             SigilTuple<bool, LinqStack<LinqList<TypeOnStack>>> ret = null;
             for(var i = 0; i < CurrentlyInScope.Count; i++)


### PR DESCRIPTION
These are essential for consumers to know. For instance, in order to spill the stack. Without IsReachable, it is impossible for an emitter to know whether to emit instructions such as a return without doing their own redundant reachability tracking.

Closes PR #1